### PR TITLE
Fix rechunking when saving as `.zarr`

### DIFF
--- a/test/test_preload.py
+++ b/test/test_preload.py
@@ -94,7 +94,9 @@ class TestClmsPreloadHandle(unittest.TestCase):
         self.assertEqual(handle.cache_store, self.mock_fs_data_store)
         self.assertTrue(handle.cleanup)
 
-        self.mock_api_token_handler.assert_called_once_with({"client_id": "test"})
+        self.mock_api_token_handler.assert_called_once_with(
+            credentials={"client_id": "test"}
+        )
         self.mock_download_task_manager.assert_called_once()
         self.mock_file_processor.assert_called_once()
 

--- a/test/test_processor.py
+++ b/test/test_processor.py
@@ -143,7 +143,10 @@ class FileProcessorTest(unittest.TestCase):
     @patch("xcube_clms.processor.rioxarray.open_rasterio")
     @patch("xcube_clms.processor.xr.concat")
     def test_postprocess_merge_and_save(
-        self, mock_xr_concat, mock_rioxarray_open_rasterio, mock_rasterio_open
+        self,
+        mock_xr_concat,
+        mock_rioxarray_open_rasterio,
+        mock_rasterio_open,
     ):
         a = xr.DataArray(
             [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]],
@@ -187,7 +190,7 @@ class FileProcessorTest(unittest.TestCase):
 
         args, _ = self.mock_file_store.write_data.call_args
         final_dataset, output_path = args
-        self.assertEqual(x_concat.to_dataset(), final_dataset)
+        self.assertEqual(x_concat.to_dataset().chunk(), final_dataset)
 
     @patch("xcube_clms.processor.rioxarray.open_rasterio")
     def test_merge_and_save_no_files(

--- a/test/test_store.py
+++ b/test/test_store.py
@@ -209,6 +209,7 @@ class ClmsDataStoreTest(unittest.TestCase):
         self.assertIsInstance(schema, JsonObjectSchema)
         self.assertIn("blocking", schema.properties)
         self.assertIn("silent", schema.properties)
+        self.assertIn("tile_size", schema.properties)
 
     @pytest.mark.vcr()
     @patch("xcube_clms.clms.new_data_store")

--- a/xcube_clms/preload.py
+++ b/xcube_clms/preload.py
@@ -60,14 +60,17 @@ class ClmsPreloadHandle(ExecutorPreloadHandle):
         self.cache_root = cache_store.root
         self._cache_fs: fsspec.AbstractFileSystem = cache_store.fs
 
-        self._token_handler = ClmsApiTokenHandler(credentials)
+        self._token_handler = ClmsApiTokenHandler(credentials=credentials)
         self.cleanup = preload_params.pop("cleanup", True)
         self._file_processor = FileProcessor(
-            self.cache_store,
-            self.cleanup,
+            cache_store=self.cache_store,
+            cleanup=self.cleanup,
+            tile_size=preload_params.pop("tile_size", None),
         )
         self._download_manager = DownloadTaskManager(
-            self._token_handler, self._url, self.cache_store
+            token_handler=self._token_handler,
+            url=self._url,
+            cache_store=self.cache_store,
         )
 
         super().__init__(

--- a/xcube_clms/processor.py
+++ b/xcube_clms/processor.py
@@ -48,7 +48,7 @@ class FileProcessor:
         self.cache_store = cache_store
         self.fs = cache_store.fs
         self.cleanup = cleanup
-        self.tile_size = tile_size or {"x": 1000, "y": 1000}
+        self.tile_size = tile_size or {"x": 1024, "y": 1024}
 
     def preprocess(self, data_id: str) -> None:
         """Performs preprocessing on the files for a given data ID.

--- a/xcube_clms/processor.py
+++ b/xcube_clms/processor.py
@@ -28,6 +28,7 @@ import fsspec
 import rasterio
 import rioxarray
 import xarray as xr
+from xcube.core.chunk import chunk_dataset
 
 from xcube_clms.constants import DATA_ID_SEPARATOR
 from xcube_clms.constants import LOG
@@ -42,10 +43,12 @@ class FileProcessor:
         self,
         cache_store,
         cleanup: bool = True,
+        tile_size: dict[str, int] = None,
     ) -> None:
         self.cache_store = cache_store
         self.fs = cache_store.fs
         self.cleanup = cleanup
+        self.tile_size = tile_size or {"x": 1000, "y": 1000}
 
     def preprocess(self, data_id: str) -> None:
         """Performs preprocessing on the files for a given data ID.
@@ -69,6 +72,10 @@ class FileProcessor:
             cache_data_id = self.fs.sep.join([data_id, files[0]])
             data = self.cache_store.open_data(cache_data_id)
             new_cache_data_id = cache_data_id.split(".")[0] + _ZARR_FORMAT
+            if self.tile_size:
+                data = chunk_dataset(
+                    data, chunk_sizes=self.tile_size, format_name=_ZARR_FORMAT
+                )
             self.cache_store.write_data(data, new_cache_data_id)
         elif len(files) == 0:
             LOG.warn("No files to preprocess!")
@@ -159,7 +166,11 @@ class FileProcessor:
         )
         new_filename = self.fs.sep.join([data_id, data_id + _ZARR_FORMAT])
 
-        self.cache_store.write_data(final_cube, new_filename)
+        # re-chunking the final dataset
+        final_chunked_cube = chunk_dataset(
+            final_cube, chunk_sizes=self.tile_size, format_name=_ZARR_FORMAT
+        )
+        self.cache_store.write_data(final_chunked_cube, new_filename)
 
 
 def find_easting_northing(name: str) -> Optional[str]:

--- a/xcube_clms/processor.py
+++ b/xcube_clms/processor.py
@@ -72,10 +72,9 @@ class FileProcessor:
             cache_data_id = self.fs.sep.join([data_id, files[0]])
             data = self.cache_store.open_data(cache_data_id)
             new_cache_data_id = cache_data_id.split(".")[0] + _ZARR_FORMAT
-            if self.tile_size:
-                data = chunk_dataset(
-                    data, chunk_sizes=self.tile_size, format_name=_ZARR_FORMAT
-                )
+            data = chunk_dataset(
+                data, chunk_sizes=self.tile_size, format_name=_ZARR_FORMAT
+            )
             self.cache_store.write_data(data, new_cache_data_id)
         elif len(files) == 0:
             LOG.warn("No files to preprocess!")

--- a/xcube_clms/store.py
+++ b/xcube_clms/store.py
@@ -184,7 +184,7 @@ class ClmsDataStore(DataStore):
             ),
             tile_size=JsonObjectSchema(
                 title="Tile size of the final data cube to be saved.",
-                default={"x": 1000, "y": 1000},
+                default={"x": 1024, "y": 1024},
             ),
         )
         return JsonObjectSchema(

--- a/xcube_clms/store.py
+++ b/xcube_clms/store.py
@@ -182,6 +182,10 @@ class ClmsDataStore(DataStore):
                 "multiple files downloaded for the same data_id. "
                 "Defaults to True.",
             ),
+            tile_size=JsonObjectSchema(
+                title="Tile size of the final data cube to be saved.",
+                default={"x": 1000, "y": 1000},
+            ),
         )
         return JsonObjectSchema(
             properties=dict(**params),


### PR DESCRIPTION
There is an issue when the Preload API tries to save the concatenated dataset of `.tif` files as `.zarr`, it encounters a problem with incompatible chunks leading to an error. This PR aims to fix that,